### PR TITLE
Add clear/confirm action handlers, add button text props

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ export default App;
 | **`selectedDateContainerStyle`** | `Style`       | `Optional` | Style of the selected date container                                                                          |
 | **`selectedDateStyle`**          | `Style`       | `Optional` | Style of the selected date                                                                                    |
 | **`ln`**                         | `string`      | `Optional` | Two letter locales string that is supported by the Moment library                                             |
-
+| **`onConfirm`**                  | `Method`      | `Optional` | This function will be executed if confirm button pressed          
+| **`onClear`**                    | `Method`      | `Optional` | This function will be executed if clear button pressed          
+| **`clearBtnTitle`**              | `string`      | `Optional` | Text for the button to clear data. If empty string passed, button will not be shown          
+| **`confirmBtnTitle`**            | `string`      | `Optional` | Text for the button to confirm selection of dates. If empty string passed, button will not be shown
 ---
 
 <br/><br/>

--- a/src/DateRangePicker.tsx
+++ b/src/DateRangePicker.tsx
@@ -27,6 +27,10 @@ interface IProps {
   selectedDateContainerStyle?: ViewStyle;
   selectedDateStyle?: TextStyle;
   ln?: string;
+  onConfirm?: () => void;
+  onClear?:() => void;
+  clearBtnTitle?: string;
+  confirmBtnTitle?: string;
 }
 
 const DateRangePicker = ({
@@ -39,6 +43,10 @@ const DateRangePicker = ({
   selectedDateContainerStyle,
   selectedDateStyle,
   ln = "en",
+  onConfirm,
+  onClear,
+  clearBtnTitle = "Clear",
+  confirmBtnTitle = "OK"
 }: IProps) => {
   const [selectedDate, setSelectedDate] = useState(moment());
 
@@ -101,7 +109,16 @@ const DateRangePicker = ({
       firstDate: "",
       secondDate: "",
     });
+    if (onClear) {
+      onClear();
+    }
   };
+
+  const onPressConfirm = () => {
+    if (onConfirm) {
+      onConfirm();
+    }
+  }
 
   const isDateSelected = () => firstDate === null || secondDate === null;
 
@@ -155,14 +172,24 @@ const DateRangePicker = ({
         selectedDateContainerStyle={selectedDateContainerStyle}
         selectedDateStyle={selectedDateStyle}
       />
-      <View style={styles.clearContainer}>
-        <Pressable
-          disabled={isDateSelected()}
-          onPress={onPressClear}
-          style={[styles.clearBtn, { opacity: isDateSelected() ? 0.3 : 1 }]}
-        >
-          <Text style={{ fontFamily: font }}>Clear</Text>
-        </Pressable>
+      <View style={styles.actionButtonsContainer}>
+        {confirmBtnTitle ? <View>
+          <Pressable
+            onPress={onPressConfirm}
+            style={[styles.actionBtn]}
+          >
+            <Text style={{ fontFamily: font }}>{confirmBtnTitle}</Text>
+          </Pressable>
+        </View> : null}
+        {clearBtnTitle ? <View>
+          <Pressable
+            disabled={isDateSelected()}
+            onPress={onPressClear}
+            style={[styles.actionBtn, { opacity: isDateSelected() ? 0.3 : 1 }]}
+          >
+            <Text style={{ fontFamily: font }}>{clearBtnTitle}</Text>
+          </Pressable>
+        </View> : null}
       </View>
     </View>
   );
@@ -185,12 +212,13 @@ const styles = StyleSheet.create({
     flex: 1,
     textAlign: "center",
   },
-  clearBtn: {
+  actionBtn: {
     paddingVertical: 3,
     paddingHorizontal: 10,
   },
-  clearContainer: {
-    flexDirection: "row-reverse",
+  actionButtonsContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
     paddingVertical: 5,
-  },
+  }
 });


### PR DESCRIPTION
Hello, thanks for this lib,
I think it will be useful to add button to confirm selection (for exemple in my case I show this component as popup on overlay and I wanted to click OK button to close popup). It's also related to #12 

So this PR add:
- 2 optional handlers (onConfirm/onClear) executed when pressing OK/Clear buttons respectively
- 2 props to be able to change text of buttons (#13). Also in some cases, we maybe don't want to show button at all (like only clear button actually). This is possible if empty string passed as prop
- 
I also updated README file respectively

Thanks for your attention